### PR TITLE
refactored Option and Result to use a single class plus statics

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -5,7 +5,7 @@
  * This library sometimes assumes a value with this key is an Option or Result
  * without explicitly checking the instance type or other properties.
  */
-export const T = Symbol("T");
+export const T_ = Symbol("T");
 export const Val = Symbol("Val");
 export const FnVal = Symbol("FnVal");
 export const EmptyArray = Object.freeze([] as any[]);

--- a/src/match.ts
+++ b/src/match.ts
@@ -1,4 +1,4 @@
-import { T, Val, FnVal } from "./common";
+import { T_, Val, FnVal } from "./common";
 import { Option, Some, None } from "./option";
 import { Result, Ok, Err } from "./result";
 
@@ -12,7 +12,7 @@ type ChainedBranches<T, U> =
 
 type BranchCondition<T> =
    | Mapped<T, boolean>
-   | (T extends { [T]: boolean } ? MonadCondition<T> : Condition<T>);
+   | (T extends { [T_]: boolean } ? MonadCondition<T> : Condition<T>);
 
 type Branch<T, U> = [BranchCondition<T>, BranchResult<T, U>];
 type Mapped<T, U> = (val: T) => U;
@@ -389,7 +389,7 @@ function matchMapped<T, U>(
    defaultBranch: DefaultBranch<U>
 ): U {
    if (Option.is(val)) {
-      if (val[T]) {
+      if (val[T_]) {
          if (pattern.Some) {
             if (typeof pattern.Some === "function") {
                return pattern.Some(val[Val]);
@@ -405,7 +405,7 @@ function matchMapped<T, U>(
          return pattern.None();
       }
    } else if (Result.is(val)) {
-      const Branch = val[T] ? pattern.Ok : pattern.Err;
+      const Branch = val[T_] ? pattern.Ok : pattern.Err;
       if (Branch) {
          if (typeof Branch === "function") {
             return Branch(val[Val]);
@@ -465,7 +465,7 @@ function matches<T>(
    }
 
    if (isObjectLike(cond)) {
-      if (T in cond) {
+      if (T_ in cond) {
          return (
             (cond as any).isLike(val) &&
             matches((cond as any)[Val], (val as any)[Val], false)

--- a/tests/docs/suite/match.test.ts
+++ b/tests/docs/suite/match.test.ts
@@ -25,7 +25,7 @@ export default function matchDocs() {
 }
 
 function mappedMatchBasic() {
-   const num = Option(10);
+   const num = Some(10);
    const res = match(num, {
       Some: (n) => n + 1,
       None: () => 0,

--- a/tests/option/suite/convert.test.ts
+++ b/tests/option/suite/convert.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { Option } from "../../../src";
+import { Option, Some } from "../../../src";
 
 export default function convert() {
    describe("from", from);
@@ -28,8 +28,8 @@ function from() {
    });
 
    it("Should be aliased by Option", () => {
-      expect(Option(0).isNone()).to.be.true;
-      expect(Option(1).unwrap()).to.equal(1);
+      expect(Option.from(0).isNone()).to.be.true;
+      expect(Some(1).unwrap()).to.equal(1);
    });
 }
 

--- a/tests/result/suite/convert.test.ts
+++ b/tests/result/suite/convert.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { Result } from "../../../src";
+import { Result, Ok } from "../../../src";
 
 export default function convert() {
    describe("from", from);
@@ -33,8 +33,8 @@ function from() {
    });
 
    it("Should be aliased by Result", () => {
-      expect(Result(0).unwrapErr()).to.equal(null);
-      expect(Result(1).unwrap()).to.equal(1);
+      expect(Result.from(0).unwrapErr()).to.equal(null);
+      expect(Ok(1).unwrap()).to.equal(1);
    });
 }
 


### PR DESCRIPTION
From the department of "where were you two weeks ago?"  

This changes does away with the distinct ResultType and Result functions, and merges everything into a class with statics. 

I can understand why one might be reluctant to merge this, since the package just hit 1.0

This refactor is a breaking change, because it gets rid of the `Result()` and `Option()` functions.  This is fine because, IMO, people should be using `Result.from()` and `Option.from()`   

However... 

That is literally the only change to the API.. I had to change 4 lines in the Unit tests to change the functions to use `from()`. All other tests pass.

 `Result(foo)` and `Option(foo)` aren't really possibilities in the Rust stdlib anyways, so I don't know if people expect them in the API. 
 
IMO it makes the implementation much more straightforward.  

Oh.. I also changed the `T` symbol variable name to `T_` just to keep myself from getting it confused with `T` the type parameter. 

Also, big shoutout to @n_n from the Typescript Discord server who was a huge help and did much of the initial design. 