### PR TITLE
Add `Result.fromCb` Method

### DIFF
--- a/src/result.ts
+++ b/src/result.ts
@@ -1,5 +1,5 @@
-import { EmptyArray, FalseyValues, IterType, T, Val, isTruthy } from "./common";
-import { None, Option, Some } from "./option";
+import { T, Val, EmptyArray, IterType, FalseyValues, isTruthy } from "./common";
+import { Option, Some, None } from "./option";
 
 export type Ok<T> = ResultType<T, never>;
 export type Err<E> = ResultType<never, E>;

--- a/tests/result/suite/convert.test.ts
+++ b/tests/result/suite/convert.test.ts
@@ -1,10 +1,49 @@
-import { expect } from "chai";
 import { Result } from "../../../src";
+import { expect } from "chai";
 
 export default function convert() {
+   describe("fromCb", fromCb);
    describe("from", from);
    describe("nonNull", nonNull);
    describe("qty", qty);
+}
+
+function fromCb() {
+   it("Should return callback return value as Some", () => {
+      expect(Result.fromCb(() => "test").isOk()).to.be.true;
+      expect(Result.fromCb(() => "test").unwrap()).to.equal("test");
+   });
+
+   it("Should return a Promise<Result<T, E>> from callback that returns promise", async () => {
+      expect(Result.fromCb(async () => "test")).to.be.instanceOf(Promise);
+      expect((await Result.fromCb(async () => "test")).unwrap()).to.equal(
+         "test"
+      );
+   });
+
+   it("It should return Err<E> | Promise<Err<E>> if callback throws", async () => {
+      expect(
+         Result.fromCb<unknown, Error>(() => {
+            throw new Error("test");
+         }).unwrapErr()
+      ).to.be.instanceOf(Error);
+
+      expect(
+         (
+            await Result.fromCb<Promise<void>, Error>(async () => {
+               throw new Error("test");
+            })
+         ).unwrapErr()
+      ).to.be.instanceOf(Error);
+
+      expect(
+         (
+            await Result.fromCb<Promise<void>, Error>(() =>
+               Promise.reject("test")
+            )
+         ).unwrapErr()
+      ).to.equal("test");
+   });
 }
 
 function from() {


### PR DESCRIPTION
We have `Result.from` but what if We want to use callback and use it's exception as Error and return value as Ok also it supports Promise, this method provides it.

I was using this method in my projects and it was really helpful while working with Promises or Exceptions, I thought that it would be nice if library includes this method.

### Example
```ts
const user: Result<User, UserNotFoundError> = Result.fromCb(() => {
  const foundUser = findUser(); // Throws if cannot find 
  return foundUser
})

if(user.isErr()) {
  const userError = user.unwrapErr();
}

user.unwrap();

// Async
const user: Result<User, UserNotFoundError> = await Result.fromCb(async () => {
  const foundUser = await findUser(); // Throws if cannot find 
  return foundUser
})

const foo = Result<Foo, FooError> = await Result.fromCb(() => Promise.resolve(5));
const bar = Result<Bar, BarError> = await Result.fromCb(() => Promise.reject(new Error()));

```