### PR TITLE
Add intoTuple

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,26 @@ const numbers: number[] | false = maybeNumbers().into(false);
 printOut(name.into());
 ```
 
+### intoTuple
+
+Convert an existing `Option`/`Result` into a tuple containing `undefined` (or a provided falsey value) and `T`.
+
+```ts
+function maybePizzaSlice(): Option<string>;
+function maybeWhiskeys(): Result<number[], Error>;
+function printOut(msg?: string): void;
+
+const [err, pizza]: [undefined, string] = maybePizzaSlice().intoTuple();
+const [err, pizza]: [null, string] = maybePizzaSlice().intoTuple(null);
+
+// Note that the intoTuple type does not reflect the E type:
+const [err, whiskeys]: [undefined, number[]] = maybeWhiskeys().into();
+const [err, whiskeys]: [false, number[]] = maybeWhiskeys().into(false);
+
+// As a function argument:
+printOut(name.intoTuple());
+```
+
 ### from
 
 Convert to an `Option`/`Result` which is `Some<T>`/`Ok<T>` unless the value is

--- a/src/option.ts
+++ b/src/option.ts
@@ -48,6 +48,32 @@ class OptionType<T> {
    }
 
    /**
+    * Returns the contained `T` and `none` in a tuple `[none, T]`. The `none`
+    * value must be falsey and defaults to `undefined`.
+    *
+    * ```
+    * const x = Ok(1);
+    * const [none, some] = x.intoTuple(false);
+    * assert.equal(none, false);
+    * assert.equal(some, 1);
+    *
+    * const x = Ok(1);
+    * assert.deepEqual(x.intoTuple(), [undefined, 1]);
+    *
+    * const x = Err(1);
+    * assert.deepEqual(x.intoTuple(), [undefined, undefined]);
+    *
+    * const x = Err(1);
+    * assert.deepEqual(x.intoTuple(false), [false, undefined]);
+    * ```
+    */
+   intoTuple(this: Option<T>): [undefined, T];
+   intoTuple<U extends FalseyValues>(this: Option<T>, none: U): [U, T];
+   intoTuple(this: Option<T>, none?: FalseyValues): [FalseyValues, T] {
+      return [none, this[Val] as T];
+   }
+
+   /**
     * Compares the Option to `cmp`, returns true if both are `Some` or both
     * are `None` and acts as a type guard.
     *

--- a/src/result.ts
+++ b/src/result.ts
@@ -52,6 +52,32 @@ export class ResultType<T, E> {
    }
 
    /**
+    * Returns the contained `T` and `err` in a tuple `[err, T]`. The `err`
+    * value must be falsey and defaults to `undefined`.
+    *
+    * ```
+    * const x = Ok(1);
+    * const [err, res] = x.intoTuple(false);
+    * assert.equal(err, false);
+    * assert.equal(res, 1);
+    *
+    * const x = Ok(1);
+    * assert.deepEqual(x.intoTuple(), [undefined, 1]);
+    *
+    * const x = Err(1);
+    * assert.deepEqual(x.intoTuple(), [undefined, undefined]);
+    *
+    * const x = Err(1);
+    * assert.deepEqual(x.intoTuple(false), [false, undefined]);
+    * ```
+    */
+   intoTuple(this: Result<T, E>): [undefined, T];
+   intoTuple<U extends FalseyValues>(this: Result<T, E>, err: U): [U, T];
+   intoTuple(this: Result<T, E>, err?: FalseyValues): [FalseyValues, T] {
+      return [err, this[Val] as T];
+   }
+
+   /**
     * Compares the Result to `cmp`, returns true if both are `Ok` or both
     * are `Err` and acts as a type guard.
     *

--- a/tests/option/suite/methods.test.ts
+++ b/tests/option/suite/methods.test.ts
@@ -13,6 +13,13 @@ export default function methods() {
       expect(None.into(null)).to.equal(null);
    });
 
+   it("intoTuple", () => {
+      expect(Some(1).intoTuple()).to.deep.equal([undefined, 1]);
+      expect(None.intoTuple()).to.deep.equal([undefined, undefined]);
+      expect(None.intoTuple(false)).to.deep.equal([false, undefined]);
+      expect(None.intoTuple(null)).to.deep.equal([null, undefined]);
+   });
+
    it("isLike", () => {
       expect(Some(1).isLike(Some(2))).to.be.true;
       expect(AsOpt(None).isLike(Some(1))).to.be.false;

--- a/tests/result/suite/methods.test.ts
+++ b/tests/result/suite/methods.test.ts
@@ -13,6 +13,13 @@ export default function methods() {
       expect(Err(1).into(null)).to.equal(null);
    });
 
+   it("intoTuple", () => {
+      expect(Ok(1).intoTuple()).to.deep.equal([undefined, 1]);
+      expect(Err(1).intoTuple()).to.deep.equal([undefined, 1]);
+      expect(Err(1).intoTuple(false)).to.deep.equal([false, 1]);
+      expect(Err(1).intoTuple(null)).to.deep.equal([null, 1]);
+   });
+
    it("isLike", () => {
       expect(Ok(1).isLike(Ok(2))).to.be.true;
       expect(Err(1).isLike(Ok(1))).to.be.false;


### PR DESCRIPTION
Adds the method `intoTuple` that was mentioned in #10.

> Convert an existing `Option`/`Result` into a tuple containing `undefined` (or a provided falsey value) and `T`.

More than happy to adjust style and details as needed. Great work on this library! Very happy using it.