### PR TITLE
Add intoTuple

### DIFF
--- a/src/result.ts
+++ b/src/result.ts
@@ -64,7 +64,7 @@ export class ResultType<T, E> {
     * assert.deepEqual(x.intoTuple(), ["error", null]);
     * ```
     */
-   intoTuple(this: Result<T, Exclude<E, null>>): [null, T] | [E, null] {
+   intoTuple(this: Result<T, E>): [null, T] | [E, null] {
       return this[T] ? [null, this[Val] as T] : [this[Val] as E, null];
    }
 

--- a/src/result.ts
+++ b/src/result.ts
@@ -51,32 +51,17 @@ export class ResultType<T, E> {
       return this[T] ? (this[Val] as T) : err;
    }
 
+   
    /**
-    * Returns the tuple `[null, T]`, or `[E, null]` if the result is `Err`, where `E` a is a non-null value.
+    * Returns a tuple of `[null, T]` if the result is `Ok`, or `[E, null]`
+    * otherwise.
     *
     * ```
-    * const o = Ok(1);
-    * const e = Err(1);
+    * const x: Result<number, string> = Ok(1);
+    * assert.deepEqual(x.intoTuple(), [null, 1]);
     *
-    * assert.deepEqual(o.intoTuple(), [null, 1]);
-    * assert.deepEqual(e.intoTuple(), [Err(1), null]);
-    * ```
-    *
-    * Allows for a destructuring pattern such as:
-    *
-    * ```
-    * function divide(divisor, dividend): Result<number, string> {
-    *    return dividend !== 0 ? Ok(divisor / dividend) : Err("You can't do that.");
-    * }
-    *
-    * const x:  = divide(1, 0);
-    * const [err, res] = x.intoTuple();
-    *
-    * if (err !== null) {
-    *    const y: [string, null] = [err, res];
-    * } else {
-    *    const y: [null, number] = [err, res];
-    * }
+    * const x: Result<number, string> = Err("error")
+    * assert.deepEqual(x.intoTuple(), ["error", null]);
     * ```
     */
    intoTuple(this: Result<T, Exclude<E, null>>): [null, T] | [E, null] {

--- a/src/result.ts
+++ b/src/result.ts
@@ -52,6 +52,38 @@ export class ResultType<T, E> {
    }
 
    /**
+    * Returns the tuple `[null, T]`, or `[E, null]` if the result is `Err`, where `E` a is a non-null value.
+    *
+    * ```
+    * const o = Ok(1);
+    * const e = Err(1);
+    *
+    * assert.deepEqual(o.intoTuple(), [null, 1]);
+    * assert.deepEqual(e.intoTuple(), [Err(1), null]);
+    * ```
+    *
+    * Allows for a destructuring pattern such as:
+    *
+    * ```
+    * function divide(divisor, dividend): Result<number, string> {
+    *    return dividend !== 0 ? Ok(divisor / dividend) : Err("You can't do that.");
+    * }
+    *
+    * const x:  = divide(1, 0);
+    * const [err, res] = x.intoTuple();
+    *
+    * if (err !== null) {
+    *    const y: [string, null] = [err, res];
+    * } else {
+    *    const y: [null, number] = [err, res];
+    * }
+    * ```
+    */
+   intoTuple(this: Result<T, Exclude<E, null>>): [null, T] | [E, null] {
+      return this[T] ? [null, this[Val] as T] : [this[Val] as E, null];
+   }
+
+   /**
     * Compares the Result to `cmp`, returns true if both are `Ok` or both
     * are `Err` and acts as a type guard.
     *

--- a/tests/result/suite/methods.test.ts
+++ b/tests/result/suite/methods.test.ts
@@ -13,6 +13,11 @@ export default function methods() {
       expect(Err(1).into(null)).to.equal(null);
    });
 
+   it("intoTuple", () => {
+      expect(Ok(1).intoTuple()).to.deep.equal([null, 1]);
+      expect(Err(1).intoTuple()).to.deep.equal([1, null]);
+   });
+
    it("isLike", () => {
       expect(Ok(1).isLike(Ok(2))).to.be.true;
       expect(Err(1).isLike(Ok(1))).to.be.false;


### PR DESCRIPTION
Adds the method `intoTuple` to `Result`.

`intoTuple` returns a tuple `[undefined, T]`, or `[Err<E>, undefined]` if the result is `Err`.

In the `Err` case, in order to allow for an `if (err)` comparison, the err member is wrapped in `Err`.

There is a question of whether the Err case tuple should contain an unwrapped error instead of `Err<E>`. One problem that may arise when returning an unwrapped err value is when is when it is a falsy value. In that case, this pattern would be unreliable:

```ts
if (err) {
   // If err is falsy, we will never reach here in the `Err` case.
} else {
   ...
}
```

I can come up with a couple of approaches:
- In the error case, return `[Err<E>, undefined]`. The caller can then call `err.unwrapErr()` within the `if (err)` clause (As demonstrated in this PR)
- Return unwrapped values without default, have the caller narrow `err !== undefined`.
- Somehow force the caller to provide a truthy default for the `err` value

Interested to hear ideas! @traverse1984 Thank you again for your time and feedback.