### PR TITLE
Fix exports in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
    "main": "dist",
    "types": "dist",
    "exports": {
-      ".": "./dist/index.js",
+      "./dist": "./dist/index.js",
       "./core": "./dist/core.js"
    },
    "files": [


### PR DESCRIPTION
When importing the package, it will complain and show this message:
```console
Error: Package subpath './dist' is not defined by "exports" in /Users/yaser/dev/my-project/node_modules/oxide.ts/package.json
at new NodeError (node:internal/errors:387:5)
at throwExportsNotFound (node:internal/modules/esm/resolve:439:9)
at packageExportsResolve (node:internal/modules/esm/resolve:718:3)
at resolveExports (node:internal/modules/cjs/loader:493:36)
at Function.Module._findPath (node:internal/modules/cjs/loader:533:31)
at Function.Module._resolveFilename (node:internal/modules/cjs/loader:942:27)
at Function.Module._load (node:internal/modules/cjs/loader:804:27)
at Module.require (node:internal/modules/cjs/loader:1022:19)
at require (node:internal/modules/cjs/helpers:102:18)
at Object.<anonymous> (/Users/yaser/dev/my-project/src/results/service.ts:14:1)
[ERROR] 16:15:04 Error: Package subpath './dist' is not defined by "exports" in /Users/yaser/dev/my-project/node_modules/oxide.ts/package.json
```

This issue is similar to this issue in jasmine-ts: https://stackoverflow.com/a/72840981/4565520